### PR TITLE
Mesos version bumped from 0.21.0 to 0.21.1.

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -13,4 +13,4 @@
     - unzip
     - python-setuptools
     - python-dev
-    - mesos={{mesos_version}}-1.0.{{ansible_distribution|lower}}{{ansible_distribution_version.split('.')|join('')}}
+    - mesos={{mesos_version}}-1.1.{{ansible_distribution|lower}}{{ansible_distribution_version.split('.')|join('')}}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 mesos_playbook_version: "0.3.2"
 
 mesos_install_mode: "master" # {master|slave|master-slave}
-mesos_version: "0.21.0"
+mesos_version: "0.21.1"
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"


### PR DESCRIPTION
Tested and successfully created up a fresh mesos cluster of Ubuntu Trusty 14.04 nodes with this change set.